### PR TITLE
Add support for API Encryption key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ optional arguments:
                         The device ESPHome api password
   -P <port>, --port <port>
                         Network port to connect to (defaults to 6053)
+  -a <auth>, --auth <auth>
+                        Auth type 'password' or 'encryption' (defaults to password)
 ```
+
+Use auth type `password` (or default) if you are using `api.password`, or `encryption` if using `api.encryption.key` in ESPHome Native API config.
 
 ## Support
 

--- a/check_esphome.py
+++ b/check_esphome.py
@@ -17,7 +17,10 @@ async def device_info():
     """Connect to an ESPHome device and get device info."""
 
     # Establish connection
-    api = aioesphomeapi.APIClient(args.hostname, args.port, args.password)
+    if args.auth == "password":
+        api = aioesphomeapi.APIClient(args.hostname, args.port, args.password)
+    else:
+        api = aioesphomeapi.APIClient(args.hostname, args.port, None, noise_psk=args.password)
     await api.connect(login=True)
 
     # Get device info
@@ -31,6 +34,7 @@ my_parser = argparse.ArgumentParser(description='Check ESPHome node')
 
 my_parser.add_argument('hostname', metavar='<hostname>', type=str, help='The hostname of the device')
 my_parser.add_argument('-P', '--port', metavar="<port>", help="Network port to connect to (defaults to 6053)", dest='port', default=6053, type=int)
+my_parser.add_argument('-a', '--auth', metavar="<auth>", help="Auth type 'password' or 'encryption' (defaults to password)", dest='auth', default="password", type=str)
 my_parser.add_argument('password', metavar='<password>', type=str, help='The esphome api password')
 
 # Execute the parse_args() method


### PR DESCRIPTION
I have started to migrate¹ my ESPHome nodes to `api.encryption.key` instead of `api.password` and needed to support that.

It add a `--auth=type` with default to `password`.

¹https://www.home-assistant.io/blog/2023/02/01/release-20232/#now-even-tighter-integrated-with-esphome